### PR TITLE
[android] [native-modules-android.md] consistent code for adding package to MainApplication.kt

### DIFF
--- a/docs/native-components-android.md
+++ b/docs/native-components-android.md
@@ -795,9 +795,12 @@ public class MyPackage implements ReactPackage {
 <TabItem value="kotlin">
 
 ```kotlin title="MainApplication.kt"
-    override fun getPackages() = PackageList(this).packages.apply {
-      add(MyPackage())
-    }
+    override fun getPackages(): List<ReactPackage> =
+      PackageList(this).packages.apply {
+          // Packages that cannot be autolinked yet can be added manually here, for example:
+          // add(MyReactNativePackage());
+          add(MyAppPackage())
+      }
 ```
 
 </TabItem>

--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -291,9 +291,12 @@ Locate ReactNativeHost’s `getPackages()` method and add your package to the pa
 <TabItem value="kotlin">
 
 ```kotlin
-override fun getPackages() = PackageList(this).packages.apply {
-    add(MyAppPackage())
-}
+override fun getPackages(): List<ReactPackage> =
+    PackageList(this).packages.apply {
+        // Packages that cannot be autolinked yet can be added manually here, for example:
+        // add(MyReactNativePackage());
+        add(MyAppPackage())
+    }
 ```
 
 </TabItem>

--- a/docs/native-modules-android.md
+++ b/docs/native-modules-android.md
@@ -291,12 +291,9 @@ Locate ReactNativeHost’s `getPackages()` method and add your package to the pa
 <TabItem value="kotlin">
 
 ```kotlin
-override fun getPackages(): List<ReactPackage> =
-    PackageList(this).packages.apply {
-        // Packages that cannot be autolinked yet can be added manually here, for example:
-        // packages.add(new MyReactNativePackage());
-        add(MyAppPackage())
-    }
+override fun getPackages() = PackageList(this).packages.apply {
+    add(MyAppPackage())
+}
 ```
 
 </TabItem>


### PR DESCRIPTION
Updated the documentation regarding adding packages to MainApplication.kt, so that they are consistent with https://reactnative.dev/docs/native-components-android

**Further reasoning**
The method listed in the pre-commit version did not correctly register the module in my testing, but the version in the proposed change does appear to work as expected

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
