### PR TITLE
Discourage using controlled inputs in React Native because they are broken

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -995,6 +995,8 @@ The color of the `TextInput` underline.
 
 ### `value`
 
+> The `value` field implementation is broken in many subtle ways and is not recommended for use. Until these bugs are fixed, we recommend sticking with `defaultValue` and uncontrolled inputs.
+
 The value to show for the text input. `TextInput` is a controlled component, which means the native value will be forced to match this value prop if provided. For most uses, this works great, but in some cases this may cause flickering - one common cause is preventing edits by keeping value the same. In addition to setting the same value, either set `editable={false}`, or set/update `maxLength` to prevent unwanted edits without flicker.
 
 | Type   |


### PR DESCRIPTION
I don't know what else to do. 

Basic controlled text editing is broken in React Native.

For example:

```js
import {useState} from 'react';
import {TextInput} from 'react-native';

let App = () => {
  const [value, setValue] = useState('');
  return (
    <TextInput
      style={{marginTop: 200, padding: 100, fontSize: 20}}
      placeholder="Edit me"
      onChangeText={text => setValue(text)}
      value={value}
    />
  );
};
export default App;

```

This is literally the simplest controlled text example you can think of.

However, React Native is not able to correctly handle if I type fast enough:

https://github.com/user-attachments/assets/f34c6248-ac24-40dc-b7c6-4521f67f0ae7

(The cursor should not lag behind typing — it causes incorrect user input.)

This is not a theoretical bug. We have it in production. It's embarrassing. Many kinds of bugs are tolerable, but this is a "hello world" example and it's broken. This is contributing to the perception that React Native is incapable of producing high quality native apps. I haven't figured out a way to convince the team to prioritize this, so maybe it should just be deprecated.

Why put it in the docs? We need to rip out all controlled inputs from the app, and I think other teams using RN or choosing to adopt it should be aware of this issue. (We've previously reported it [in April](https://github.com/facebook/react-native/issues/44157).) It's not a fun thing to discover when you already have a lot of existing code. It's better to know early.

This is also far from the only bug related to controlled inputs. Here's another one I just ran into today: https://github.com/facebook/react-native/issues/46850. That's actually what pushed me over the line to file this issue.

**The typical workaround is to use `defaultValue` and avoid controlled inputs completely** — it should be a recommendation if this cannot get prioritized.

I know there's been a focus on the team on getting things fixed with the New Architecture. That's understandable. However it's equally broken in the New Architecture.

https://github.com/user-attachments/assets/421866e2-5505-48f0-9b9b-a6575ad1a998

I know it takes a lot to develop the framework and this issue may simply not be enough of a priority but I think it's important to communicate honestly when one of the most fundamental features is broken at the "hello world" level.

Hence, this PR.

Thanks for consideration.

