### PR TITLE
Document ListItemComponent prop on the FlatList page

### DIFF
--- a/docs/flatlist.md
+++ b/docs/flatlist.md
@@ -484,6 +484,16 @@ Styling for internal View for `ListHeaderComponent`.
 
 ---
 
+### `ListItemComponent`
+
+Each data item is rendered using this element, as an alternative to `renderItem`. It receives the same props, and takes precedence over `renderItem` when both are provided.
+
+| Type               |
+| ------------------ |
+| component, element |
+
+---
+
 ### `columnWrapperStyle`
 
 Optional custom style for multi-item rows generated when `numColumns > 1`.


### PR DESCRIPTION
The FlatList page documents every inherited `List*Component` prop (`ListEmptyComponent`, `ListFooterComponent`, `ListHeaderComponent`, `ItemSeparatorComponent`) except `ListItemComponent`, so it looks like the prop does not exist on FlatList.

It does. `FlatList._renderer` renders `<ListItemComponent {...props} />` and falls back to `renderItem` only when it is not set, so it also takes precedence when both are passed:

https://github.com/react/react-native/blob/main/packages/react-native/Libraries/Lists/FlatList.js#L624

It is already documented on the [VirtualizedList page](https://reactnative.dev/docs/virtualizedlist#listitemcomponent). This adds the same entry to FlatList, in alphabetical position next to the other `List*Component` props, and notes the precedence behaviour.

Type is listed as `component, element` to match the prop's type and the neighbouring entries on the same page.
