### PR TITLE
fix Docs: add patch to CLI --version

### DIFF
--- a/docs/the-new-architecture/pure-cxx-modules.md
+++ b/docs/the-new-architecture/pure-cxx-modules.md
@@ -19,7 +19,7 @@ In this guide, we will go through the creation of a pure C++ Turbo Native Module
 The rest of this guide assumes that you have created your application running the command:
 
 <CodeBlock language="bash" title="shell">
-{`npx @react-native-community/cli@latest init SampleApp --version ${getCurrentVersion()}`}
+{`npx @react-native-community/cli@latest init SampleApp --version "${getCurrentVersion()}"`}
 </CodeBlock>
 
 ## 1. Create the JS specs

--- a/docs/the-new-architecture/using-codegen.mdx
+++ b/docs/the-new-architecture/using-codegen.mdx
@@ -19,7 +19,7 @@ The **Codegen** process is tightly coupled with the build of the app, and the sc
 For the sake of this guide, create a project using the React Native CLI as follows:
 
 <CodeBlock language="bash" title="shell">
-  {`npx @react-native-community/cli@latest init SampleApp --version ${getCurrentVersion()}`}
+  {`npx @react-native-community/cli@latest init SampleApp --version "${getCurrentVersion()}"`}
 </CodeBlock>
 
 **Codegen** is used to generate the glue-code for your custom modules or components. See the guides for Turbo Native Modules and Fabric Native Components for more details on how to create them.

--- a/docs/turbo-native-modules.md
+++ b/docs/turbo-native-modules.md
@@ -24,7 +24,7 @@ The basic steps are:
 Lets work through each of these steps by building an example Turbo Native Module. The rest of this guide assume that you have created your application running the command:
 
 <CodeBlock language="bash" title="shell">
-{`npx @react-native-community/cli@latest init TurboModuleExample --version ${getCurrentVersion()}`}
+{`npx @react-native-community/cli@latest init TurboModuleExample --version "${getCurrentVersion()}"`}
 </CodeBlock>
 
 ## Native Persistent Storage

--- a/website/src/getCurrentVersion.ts
+++ b/website/src/getCurrentVersion.ts
@@ -2,5 +2,10 @@ import {useActiveVersion} from '@docusaurus/plugin-content-docs/client';
 
 export function getCurrentVersion() {
   const version = useActiveVersion(undefined);
-  return version.label === 'Next' ? 'latest' : version.label;
+  if (!version || version.label === 'Next') {
+    return 'latest';
+  }
+  return /^\d+\.\d+$/.test(version.label)
+    ? `${version.label}.0`
+    : version.label;
 }

--- a/website/versioned_docs/version-0.87/the-new-architecture/pure-cxx-modules.md
+++ b/website/versioned_docs/version-0.87/the-new-architecture/pure-cxx-modules.md
@@ -19,7 +19,7 @@ In this guide, we will go through the creation of a pure C++ Turbo Native Module
 The rest of this guide assumes that you have created your application running the command:
 
 <CodeBlock language="bash" title="shell">
-{`npx @react-native-community/cli@latest init SampleApp --version ${getCurrentVersion()}`}
+{`npx @react-native-community/cli@latest init SampleApp --version "${getCurrentVersion()}"`}
 </CodeBlock>
 
 ## 1. Create the JS specs

--- a/website/versioned_docs/version-0.87/the-new-architecture/using-codegen.mdx
+++ b/website/versioned_docs/version-0.87/the-new-architecture/using-codegen.mdx
@@ -19,7 +19,7 @@ The **Codegen** process is tightly coupled with the build of the app, and the sc
 For the sake of this guide, create a project using the React Native CLI as follows:
 
 <CodeBlock language="bash" title="shell">
-  {`npx @react-native-community/cli@latest init SampleApp --version ${getCurrentVersion()}`}
+  {`npx @react-native-community/cli@latest init SampleApp --version "${getCurrentVersion()}"`}
 </CodeBlock>
 
 **Codegen** is used to generate the glue-code for your custom modules or components. See the guides for Turbo Native Modules and Fabric Native Components for more details on how to create them.

--- a/website/versioned_docs/version-0.87/turbo-native-modules.md
+++ b/website/versioned_docs/version-0.87/turbo-native-modules.md
@@ -24,7 +24,7 @@ The basic steps are:
 Lets work through each of these steps by building an example Turbo Native Module. The rest of this guide assume that you have created your application running the command:
 
 <CodeBlock language="bash" title="shell">
-{`npx @react-native-community/cli@latest init TurboModuleExample --version ${getCurrentVersion()}`}
+{`npx @react-native-community/cli@latest init TurboModuleExample --version "${getCurrentVersion()}"`}
 </CodeBlock>
 
 ## Native Persistent Storage


### PR DESCRIPTION
## Fixes #5173

The CLI looks up npm templates by exact version. Docs used the Docusaurus label (`0.86` / `0.87`), so `init --version 0.86` failed.

`getCurrentVersion()` now returns a patch (`0.87.0`).

Appending `.0` in the snippet made Prism (bash) treat `0.87` as a number and `.0` as another token, so the version was two colors (screenshot of Highlight). The value is quoted (`--version "0.87.0"`) so it highlights as one string. The CLI accepts that the same way.

## Screenshots

**CLI (before )**, command from the docs:

<img width="858" height="234" alt="Captura de pantalla 2026-08-31 a las 23 21 55" src="https://github.com/user-attachments/assets/da3f5262-1b0e-4f3e-a227-48d2f2aebf9d" />


**CLI (after)**,  `--version "0.87.0"`

<img width="880" height="429" alt="Captura de pantalla 2026-08-31 a las 23 24 59" src="https://github.com/user-attachments/assets/1253a4dc-bb17-4619-827f-84e7b0498e8c" />

**Docs (before)**, https://reactnative.dev/docs/turbo-native-modules-introduction

<img width="854" height="157" alt="Captura de pantalla 2026-08-31 a las 23 19 38" src="https://github.com/user-attachments/assets/d1dcd960-7d71-4c62-81b7-f80daa53d9d5" />


**Highlight (without quotes)**,  `--version 0.87.0`

<img width="850" height="151" alt="Captura de pantalla 2026-08-31 a las 23 23 42" src="https://github.com/user-attachments/assets/65101e41-c2d9-4d4d-8257-54d2eb8db742" />


**Docs (after)**

<img width="854" height="153" alt="Captura de pantalla 2026-08-31 a las 23 20 23" src="https://github.com/user-attachments/assets/5a99be16-23f6-46d9-816c-6b50e20c503b" />


## Affected pages

https://reactnative.dev/docs/turbo-native-modules-introduction
https://reactnative.dev/docs/the-new-architecture/using-codegen
https://reactnative.dev/docs/the-new-architecture/pure-cxx-modules

## Issue
#5173
