### PR TITLE
fix a11y on home: one h1 and named partner links

### DIFF
--- a/website/src/components/Home/CallToAction/index.tsx
+++ b/website/src/components/Home/CallToAction/index.tsx
@@ -17,7 +17,7 @@ function CallToAction() {
       <div className={styles.background} />
       <div className={styles.container}>
         <Logo />
-        <h1 className={styles.title}>Welcome to the React Native community</h1>
+        <h2 className={styles.title}>Welcome to the React Native community</h2>
         <a href="/docs/environment-setup" className={styles.primaryButton}>
           Get Started
         </a>

--- a/website/src/components/Home/Community/PartnersShowcase.tsx
+++ b/website/src/components/Home/Community/PartnersShowcase.tsx
@@ -19,24 +19,29 @@ import styles from './styles.module.css';
 const PARTNERS = [
   {
     href: 'https://callstack.com/',
-    logo: <CallstackWordmark />,
+    name: 'Callstack',
+    logo: <CallstackWordmark aria-hidden />,
   },
   {
     href: 'https://expo.dev/',
+    name: 'Expo',
     className: styles.expo,
-    logo: <ExpoWordmark />,
+    logo: <ExpoWordmark aria-hidden />,
   },
   {
     href: 'https://infinite.red/',
-    logo: <InfiniteRedWordmark />,
+    name: 'Infinite Red',
+    logo: <InfiniteRedWordmark aria-hidden />,
   },
   {
     href: 'https://www.microsoft.com/',
-    logo: <MicrosoftWordmark />,
+    name: 'Microsoft',
+    logo: <MicrosoftWordmark aria-hidden />,
   },
   {
     href: 'https://swmansion.com/',
-    logo: <SWMWordmark />,
+    name: 'Software Mansion',
+    logo: <SWMWordmark aria-hidden />,
   },
 ];
 
@@ -49,13 +54,14 @@ export default function PartnersShowcase() {
 
   return (
     <div className={styles.partnersContainer}>
-      {partners.map(({href, className, logo}) => (
+      {partners.map(({href, name, className, logo}) => (
         <a
           key={href}
           href={href}
           target="_blank"
           rel="noopener noreferrer"
-          className={className}>
+          className={className}
+          aria-label={name}>
           {logo}
         </a>
       ))}

--- a/website/src/components/Home/SectionTitle/index.tsx
+++ b/website/src/components/Home/SectionTitle/index.tsx
@@ -17,10 +17,8 @@ type Props = {
 function SectionTitle({title, description}: Props) {
   return (
     <div className={styles.container}>
-      <h1 className={styles.title}>{title}</h1>
-      {description ? (
-        <h3 className={styles.description}>{description}</h3>
-      ) : null}
+      <h2 className={styles.title}>{title}</h2>
+      {description ? <p className={styles.description}>{description}</p> : null}
     </div>
   );
 }

--- a/website/src/types/index.d.ts
+++ b/website/src/types/index.d.ts
@@ -4,6 +4,7 @@ export type ShowcaseData = Record<string, ShowcaseApp[]>;
 
 export type PartnerLink = {
   href: string;
+  name: string;
   className?: string;
   logo: ReactNode;
 };


### PR DESCRIPTION
This pull implements some accessibility fixes on [Home](https://reactnative.dev/).

## SUMMARY

Section titles used `h1` + `h3`, and the bottom CTA was another `h1`, so the page had several top-level headings.
Partner wordmarks are inline SVGs inside links with no text, so Lighthouse flagged empty links.

**FIXES**
- `SectionTitle` has now `h2` + `p` nodes.
- CTA heading is `h2` nodes.
- Partner links now have `aria-label`; 

**AUDITED RESULT**

Lighthouse Accessibility on the homepage: **93 → 97**.

---

## Screenshots

**Headings (before)** — several `h1` on https://reactnative.dev/

<img width="453" height="47" alt="Captura de pantalla 2026-09-01 a las 20 41 31" src="https://github.com/user-attachments/assets/b2baaad1-761f-441e-8ae5-0d0f8699c70b" />


**Headings (after)** — one `h1` (“React Native” title on hero)

<img width="453" height="47" alt="Captura de pantalla 2026-09-01 a las 20 41 38" src="https://github.com/user-attachments/assets/b53fc72f-471b-4db9-9dba-53d2df11841d" />

**Partner links (before)** — empty names in Lighthouse

<img width="468" height="493" alt="Captura de pantalla 2026-09-01 a las 20 40 19" src="https://github.com/user-attachments/assets/22f57c58-fdb6-40ef-8f62-a61e85911e86" />


**Partner links (after)** — `aria-label` on each company link

<img width="725" height="248" alt="Captura de pantalla 2026-09-01 a las 21 24 22" src="https://github.com/user-attachments/assets/68ad87d2-4381-424e-aec4-9ecfafc82f8e" />


**Lighthouse (before)** — 93

<img width="222" height="226" alt="image" src="https://github.com/user-attachments/assets/8d948044-3e39-444a-ba00-76a5769ca825" />


**Lighthouse (after)** — 97

<img width="224" height="218" alt="image" src="https://github.com/user-attachments/assets/03636f38-773e-408a-b920-e786ac14fefb" />

