### PR TITLE
feat: Mark an `ImageBackground` component as deprecated (0.87.x+)

### DIFF
--- a/docs/imagebackground.md
+++ b/docs/imagebackground.md
@@ -1,7 +1,11 @@
 ---
 id: imagebackground
-title: ImageBackground
+title: '🗑️ ImageBackground'
 ---
+
+:::warning[Deprecated]
+Use a [`View`](view.md) with an absolutely positioned [`Image`](image.md) instead.
+:::
 
 A common feature request from developers familiar with the web is `background-image`. To handle this use case, you can use the `<ImageBackground>` component, which has the same props as `<Image>`, and add whatever children to it you would like to layer on top of it.
 

--- a/website/versioned_docs/version-0.87/imagebackground.md
+++ b/website/versioned_docs/version-0.87/imagebackground.md
@@ -1,7 +1,11 @@
 ---
 id: imagebackground
-title: ImageBackground
+title: '🗑️ ImageBackground'
 ---
+
+:::warning[Deprecated]
+Use a [`View`](view.md) with an absolutely positioned [`Image`](image.md) instead.
+:::
 
 A common feature request from developers familiar with the web is `background-image`. To handle this use case, you can use the `<ImageBackground>` component, which has the same props as `<Image>`, and add whatever children to it you would like to layer on top of it.
 


### PR DESCRIPTION
I used same style as a [`SafeAreaView `](https://reactnative.dev/docs/safeareaview)



Commit: https://github.com/react/react-native/commit/2361189716afbcced6ee2cdb0fd860cf23460850

Version Check:

<img width="920" height="444" alt="Screenshot 2026-09-10 at 12 27 35" src="https://github.com/user-attachments/assets/98a0ae96-8c66-41f2-a1e3-842f8dd7b08a" />

