### PR TITLE
feat: Add missing `ReactNativeVersion` API

### DIFF
--- a/docs/components-and-apis.md
+++ b/docs/components-and-apis.md
@@ -199,6 +199,12 @@ These components may be useful for certain applications. For an exhaustive list 
     </a>
   </div>
   <div className="component">
+    <a href="./reactnativeversion">
+      <h3>ReactNativeVersion</h3>
+      <p>Exposes the resolved React Native package version on the JS side.</p>
+    </a>
+  </div>
+  <div className="component">
     <a href="./refreshcontrol">
       <h3>RefreshControl</h3>
       <p>This component is used inside a <code>ScrollView</code> to add pull to refresh functionality.</p>

--- a/docs/reactnativeversion.md
+++ b/docs/reactnativeversion.md
@@ -1,0 +1,83 @@
+---
+id: reactnativeversion
+title: ReactNativeVersion
+---
+
+```tsx
+import {ReactNativeVersion} from 'react-native';
+```
+
+The `ReactNativeVersion` API exposes the version of the resolved `react-native` package on JS side. Apps and libraries can use it to check compatibility or enable version-specific behavior.
+
+:::note
+
+Also, we have [`Platform.constants.reactNativeVersion`](platform#constants) in our public API already. **However**, this is the per-platform _**native-reported**_ React Native version.
+
+:::
+
+## Example
+
+```tsx
+import {ReactNativeVersion} from 'react-native';
+
+const version = ReactNativeVersion.getVersionString(); // 0.88.1
+const {major, minor, patch, prerelease} = ReactNativeVersion;
+major; // 0
+minor; // 88
+patch; // 1
+prerelease; // null
+```
+
+---
+
+# Reference
+
+## Properties
+
+### `major`
+
+```tsx
+static major: number;
+```
+
+The major version number of the resolved `react-native` package.
+
+---
+
+### `minor`
+
+```tsx
+static minor: number;
+```
+
+The minor version number of the resolved `react-native` package.
+
+---
+
+### `patch`
+
+```tsx
+static patch: number;
+```
+
+The patch version number of the resolved `react-native` package.
+
+---
+
+### `prerelease`
+
+```tsx
+static prerelease: string | null;
+```
+
+The prerelease tag for the resolved `react-native` package, or `null` for stable releases.
+
+## Methods
+
+### `getVersionString()`
+
+```tsx
+static getVersionString(): string;
+```
+
+Returns the full version string in the format `major.minor.patch` or `major.minor.patch-prerelease`.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -214,6 +214,7 @@ export default {
       'pixelratio',
       'platform',
       'platformcolor',
+      'reactnativeversion',
       'roottag',
       'share',
       'stylesheet',

--- a/website/versioned_docs/version-0.82/components-and-apis.md
+++ b/website/versioned_docs/version-0.82/components-and-apis.md
@@ -199,6 +199,12 @@ These components may be useful for certain applications. For an exhaustive list 
     </a>
   </div>
   <div className="component">
+    <a href="./reactnativeversion">
+      <h3>ReactNativeVersion</h3>
+      <p>Exposes the resolved React Native package version on the JS side.</p>
+    </a>
+  </div>
+  <div className="component">
     <a href="./refreshcontrol">
       <h3>RefreshControl</h3>
       <p>This component is used inside a <code>ScrollView</code> to add pull to refresh functionality.</p>

--- a/website/versioned_docs/version-0.82/reactnativeversion.md
+++ b/website/versioned_docs/version-0.82/reactnativeversion.md
@@ -1,0 +1,83 @@
+---
+id: reactnativeversion
+title: ReactNativeVersion
+---
+
+```tsx
+import {ReactNativeVersion} from 'react-native';
+```
+
+The `ReactNativeVersion` API exposes the version of the resolved `react-native` package on JS side. Apps and libraries can use it to check compatibility or enable version-specific behavior.
+
+:::note
+
+Also, we have [`Platform.constants.reactNativeVersion`](platform#constants) in our public API already. **However**, this is the per-platform _**native-reported**_ React Native version.
+
+:::
+
+## Example
+
+```tsx
+import {ReactNativeVersion} from 'react-native';
+
+const version = ReactNativeVersion.getVersionString(); // 0.82.1
+const {major, minor, patch, prerelease} = ReactNativeVersion;
+major; // 0
+minor; // 82
+patch; // 1
+prerelease; // null
+```
+
+---
+
+# Reference
+
+## Properties
+
+### `major`
+
+```tsx
+static major: number;
+```
+
+The major version number of the resolved `react-native` package.
+
+---
+
+### `minor`
+
+```tsx
+static minor: number;
+```
+
+The minor version number of the resolved `react-native` package.
+
+---
+
+### `patch`
+
+```tsx
+static patch: number;
+```
+
+The patch version number of the resolved `react-native` package.
+
+---
+
+### `prerelease`
+
+```tsx
+static prerelease: string | null;
+```
+
+The prerelease tag for the resolved `react-native` package, or `null` for stable releases.
+
+## Methods
+
+### `getVersionString()`
+
+```tsx
+static getVersionString(): string;
+```
+
+Returns the full version string in the format `major.minor.patch` or `major.minor.patch-prerelease`.

--- a/website/versioned_docs/version-0.83/components-and-apis.md
+++ b/website/versioned_docs/version-0.83/components-and-apis.md
@@ -199,6 +199,12 @@ These components may be useful for certain applications. For an exhaustive list 
     </a>
   </div>
   <div className="component">
+    <a href="./reactnativeversion">
+      <h3>ReactNativeVersion</h3>
+      <p>Exposes the resolved React Native package version on the JS side.</p>
+    </a>
+  </div>
+  <div className="component">
     <a href="./refreshcontrol">
       <h3>RefreshControl</h3>
       <p>This component is used inside a <code>ScrollView</code> to add pull to refresh functionality.</p>

--- a/website/versioned_docs/version-0.83/reactnativeversion.md
+++ b/website/versioned_docs/version-0.83/reactnativeversion.md
@@ -1,0 +1,83 @@
+---
+id: reactnativeversion
+title: ReactNativeVersion
+---
+
+```tsx
+import {ReactNativeVersion} from 'react-native';
+```
+
+The `ReactNativeVersion` API exposes the version of the resolved `react-native` package on JS side. Apps and libraries can use it to check compatibility or enable version-specific behavior.
+
+:::note
+
+Also, we have [`Platform.constants.reactNativeVersion`](platform#constants) in our public API already. **However**, this is the per-platform _**native-reported**_ React Native version.
+
+:::
+
+## Example
+
+```tsx
+import {ReactNativeVersion} from 'react-native';
+
+const version = ReactNativeVersion.getVersionString(); // 0.83.10
+const {major, minor, patch, prerelease} = ReactNativeVersion;
+major; // 0
+minor; // 83
+patch; // 10
+prerelease; // null
+```
+
+---
+
+# Reference
+
+## Properties
+
+### `major`
+
+```tsx
+static major: number;
+```
+
+The major version number of the resolved `react-native` package.
+
+---
+
+### `minor`
+
+```tsx
+static minor: number;
+```
+
+The minor version number of the resolved `react-native` package.
+
+---
+
+### `patch`
+
+```tsx
+static patch: number;
+```
+
+The patch version number of the resolved `react-native` package.
+
+---
+
+### `prerelease`
+
+```tsx
+static prerelease: string | null;
+```
+
+The prerelease tag for the resolved `react-native` package, or `null` for stable releases.
+
+## Methods
+
+### `getVersionString()`
+
+```tsx
+static getVersionString(): string;
+```
+
+Returns the full version string in the format `major.minor.patch` or `major.minor.patch-prerelease`.

--- a/website/versioned_docs/version-0.84/components-and-apis.md
+++ b/website/versioned_docs/version-0.84/components-and-apis.md
@@ -199,6 +199,12 @@ These components may be useful for certain applications. For an exhaustive list 
     </a>
   </div>
   <div className="component">
+    <a href="./reactnativeversion">
+      <h3>ReactNativeVersion</h3>
+      <p>Exposes the resolved React Native package version on the JS side.</p>
+    </a>
+  </div>
+  <div className="component">
     <a href="./refreshcontrol">
       <h3>RefreshControl</h3>
       <p>This component is used inside a <code>ScrollView</code> to add pull to refresh functionality.</p>

--- a/website/versioned_docs/version-0.84/reactnativeversion.md
+++ b/website/versioned_docs/version-0.84/reactnativeversion.md
@@ -1,0 +1,83 @@
+---
+id: reactnativeversion
+title: ReactNativeVersion
+---
+
+```tsx
+import {ReactNativeVersion} from 'react-native';
+```
+
+The `ReactNativeVersion` API exposes the version of the resolved `react-native` package on JS side. Apps and libraries can use it to check compatibility or enable version-specific behavior.
+
+:::note
+
+Also, we have [`Platform.constants.reactNativeVersion`](platform#constants) in our public API already. **However**, this is the per-platform _**native-reported**_ React Native version.
+
+:::
+
+## Example
+
+```tsx
+import {ReactNativeVersion} from 'react-native';
+
+const version = ReactNativeVersion.getVersionString(); // 0.84.1
+const {major, minor, patch, prerelease} = ReactNativeVersion;
+major; // 0
+minor; // 84
+patch; // 1
+prerelease; // null
+```
+
+---
+
+# Reference
+
+## Properties
+
+### `major`
+
+```tsx
+static major: number;
+```
+
+The major version number of the resolved `react-native` package.
+
+---
+
+### `minor`
+
+```tsx
+static minor: number;
+```
+
+The minor version number of the resolved `react-native` package.
+
+---
+
+### `patch`
+
+```tsx
+static patch: number;
+```
+
+The patch version number of the resolved `react-native` package.
+
+---
+
+### `prerelease`
+
+```tsx
+static prerelease: string | null;
+```
+
+The prerelease tag for the resolved `react-native` package, or `null` for stable releases.
+
+## Methods
+
+### `getVersionString()`
+
+```tsx
+static getVersionString(): string;
+```
+
+Returns the full version string in the format `major.minor.patch` or `major.minor.patch-prerelease`.

--- a/website/versioned_docs/version-0.85/components-and-apis.md
+++ b/website/versioned_docs/version-0.85/components-and-apis.md
@@ -199,6 +199,12 @@ These components may be useful for certain applications. For an exhaustive list 
     </a>
   </div>
   <div className="component">
+    <a href="./reactnativeversion">
+      <h3>ReactNativeVersion</h3>
+      <p>Exposes the resolved React Native package version on the JS side.</p>
+    </a>
+  </div>
+  <div className="component">
     <a href="./refreshcontrol">
       <h3>RefreshControl</h3>
       <p>This component is used inside a <code>ScrollView</code> to add pull to refresh functionality.</p>

--- a/website/versioned_docs/version-0.85/reactnativeversion.md
+++ b/website/versioned_docs/version-0.85/reactnativeversion.md
@@ -1,0 +1,83 @@
+---
+id: reactnativeversion
+title: ReactNativeVersion
+---
+
+```tsx
+import {ReactNativeVersion} from 'react-native';
+```
+
+The `ReactNativeVersion` API exposes the version of the resolved `react-native` package on JS side. Apps and libraries can use it to check compatibility or enable version-specific behavior.
+
+:::note
+
+Also, we have [`Platform.constants.reactNativeVersion`](platform#constants) in our public API already. **However**, this is the per-platform _**native-reported**_ React Native version.
+
+:::
+
+## Example
+
+```tsx
+import {ReactNativeVersion} from 'react-native';
+
+const version = ReactNativeVersion.getVersionString(); // 0.85.3
+const {major, minor, patch, prerelease} = ReactNativeVersion;
+major; // 0
+minor; // 85
+patch; // 3
+prerelease; // null
+```
+
+---
+
+# Reference
+
+## Properties
+
+### `major`
+
+```tsx
+static major: number;
+```
+
+The major version number of the resolved `react-native` package.
+
+---
+
+### `minor`
+
+```tsx
+static minor: number;
+```
+
+The minor version number of the resolved `react-native` package.
+
+---
+
+### `patch`
+
+```tsx
+static patch: number;
+```
+
+The patch version number of the resolved `react-native` package.
+
+---
+
+### `prerelease`
+
+```tsx
+static prerelease: string | null;
+```
+
+The prerelease tag for the resolved `react-native` package, or `null` for stable releases.
+
+## Methods
+
+### `getVersionString()`
+
+```tsx
+static getVersionString(): string;
+```
+
+Returns the full version string in the format `major.minor.patch` or `major.minor.patch-prerelease`.

--- a/website/versioned_docs/version-0.86/components-and-apis.md
+++ b/website/versioned_docs/version-0.86/components-and-apis.md
@@ -199,6 +199,12 @@ These components may be useful for certain applications. For an exhaustive list 
     </a>
   </div>
   <div className="component">
+    <a href="./reactnativeversion">
+      <h3>ReactNativeVersion</h3>
+      <p>Exposes the resolved React Native package version on the JS side.</p>
+    </a>
+  </div>
+  <div className="component">
     <a href="./refreshcontrol">
       <h3>RefreshControl</h3>
       <p>This component is used inside a <code>ScrollView</code> to add pull to refresh functionality.</p>

--- a/website/versioned_docs/version-0.86/reactnativeversion.md
+++ b/website/versioned_docs/version-0.86/reactnativeversion.md
@@ -1,0 +1,83 @@
+---
+id: reactnativeversion
+title: ReactNativeVersion
+---
+
+```tsx
+import {ReactNativeVersion} from 'react-native';
+```
+
+The `ReactNativeVersion` API exposes the version of the resolved `react-native` package on JS side. Apps and libraries can use it to check compatibility or enable version-specific behavior.
+
+:::note
+
+Also, we have [`Platform.constants.reactNativeVersion`](platform#constants) in our public API already. **However**, this is the per-platform _**native-reported**_ React Native version.
+
+:::
+
+## Example
+
+```tsx
+import {ReactNativeVersion} from 'react-native';
+
+const version = ReactNativeVersion.getVersionString(); // 0.86.3
+const {major, minor, patch, prerelease} = ReactNativeVersion;
+major; // 0
+minor; // 86
+patch; // 3
+prerelease; // null
+```
+
+---
+
+# Reference
+
+## Properties
+
+### `major`
+
+```tsx
+static major: number;
+```
+
+The major version number of the resolved `react-native` package.
+
+---
+
+### `minor`
+
+```tsx
+static minor: number;
+```
+
+The minor version number of the resolved `react-native` package.
+
+---
+
+### `patch`
+
+```tsx
+static patch: number;
+```
+
+The patch version number of the resolved `react-native` package.
+
+---
+
+### `prerelease`
+
+```tsx
+static prerelease: string | null;
+```
+
+The prerelease tag for the resolved `react-native` package, or `null` for stable releases.
+
+## Methods
+
+### `getVersionString()`
+
+```tsx
+static getVersionString(): string;
+```
+
+Returns the full version string in the format `major.minor.patch` or `major.minor.patch-prerelease`.

--- a/website/versioned_docs/version-0.87/components-and-apis.md
+++ b/website/versioned_docs/version-0.87/components-and-apis.md
@@ -199,6 +199,12 @@ These components may be useful for certain applications. For an exhaustive list 
     </a>
   </div>
   <div className="component">
+    <a href="./reactnativeversion">
+      <h3>ReactNativeVersion</h3>
+      <p>Exposes the resolved React Native package version on the JS side.</p>
+    </a>
+  </div>
+  <div className="component">
     <a href="./refreshcontrol">
       <h3>RefreshControl</h3>
       <p>This component is used inside a <code>ScrollView</code> to add pull to refresh functionality.</p>

--- a/website/versioned_docs/version-0.87/reactnativeversion.md
+++ b/website/versioned_docs/version-0.87/reactnativeversion.md
@@ -1,0 +1,83 @@
+---
+id: reactnativeversion
+title: ReactNativeVersion
+---
+
+```tsx
+import {ReactNativeVersion} from 'react-native';
+```
+
+The `ReactNativeVersion` API exposes the version of the resolved `react-native` package on JS side. Apps and libraries can use it to check compatibility or enable version-specific behavior.
+
+:::note
+
+Also, we have [`Platform.constants.reactNativeVersion`](platform#constants) in our public API already. **However**, this is the per-platform _**native-reported**_ React Native version.
+
+:::
+
+## Example
+
+```tsx
+import {ReactNativeVersion} from 'react-native';
+
+const version = ReactNativeVersion.getVersionString(); // 0.87.1
+const {major, minor, patch, prerelease} = ReactNativeVersion;
+major; // 0
+minor; // 87
+patch; // 1
+prerelease; // null
+```
+
+---
+
+# Reference
+
+## Properties
+
+### `major`
+
+```tsx
+static major: number;
+```
+
+The major version number of the resolved `react-native` package.
+
+---
+
+### `minor`
+
+```tsx
+static minor: number;
+```
+
+The minor version number of the resolved `react-native` package.
+
+---
+
+### `patch`
+
+```tsx
+static patch: number;
+```
+
+The patch version number of the resolved `react-native` package.
+
+---
+
+### `prerelease`
+
+```tsx
+static prerelease: string | null;
+```
+
+The prerelease tag for the resolved `react-native` package, or `null` for stable releases.
+
+## Methods
+
+### `getVersionString()`
+
+```tsx
+static getVersionString(): string;
+```
+
+Returns the full version string in the format `major.minor.patch` or `major.minor.patch-prerelease`.

--- a/website/versioned_sidebars/version-0.82-sidebars.json
+++ b/website/versioned_sidebars/version-0.82-sidebars.json
@@ -228,6 +228,7 @@
       "pixelratio",
       "platform",
       "platformcolor",
+      "reactnativeversion",
       "roottag",
       "share",
       "stylesheet",

--- a/website/versioned_sidebars/version-0.83-sidebars.json
+++ b/website/versioned_sidebars/version-0.83-sidebars.json
@@ -228,6 +228,7 @@
       "pixelratio",
       "platform",
       "platformcolor",
+      "reactnativeversion",
       "roottag",
       "share",
       "stylesheet",

--- a/website/versioned_sidebars/version-0.84-sidebars.json
+++ b/website/versioned_sidebars/version-0.84-sidebars.json
@@ -239,6 +239,7 @@
       "pixelratio",
       "platform",
       "platformcolor",
+      "reactnativeversion",
       "roottag",
       "share",
       "stylesheet",

--- a/website/versioned_sidebars/version-0.85-sidebars.json
+++ b/website/versioned_sidebars/version-0.85-sidebars.json
@@ -239,6 +239,7 @@
       "pixelratio",
       "platform",
       "platformcolor",
+      "reactnativeversion",
       "roottag",
       "share",
       "stylesheet",

--- a/website/versioned_sidebars/version-0.86-sidebars.json
+++ b/website/versioned_sidebars/version-0.86-sidebars.json
@@ -224,6 +224,7 @@
       "pixelratio",
       "platform",
       "platformcolor",
+      "reactnativeversion",
       "roottag",
       "share",
       "stylesheet",

--- a/website/versioned_sidebars/version-0.87-sidebars.json
+++ b/website/versioned_sidebars/version-0.87-sidebars.json
@@ -223,6 +223,7 @@
       "pixelratio",
       "platform",
       "platformcolor",
+      "reactnativeversion",
       "roottag",
       "share",
       "stylesheet",


### PR DESCRIPTION
From React Native `0.82.x` the `ReactNativeVersion` can be imported from `'react-native/index.js'` module 

Commit: https://github.com/react/react-native/commit/ec5638abd0e872be62b6ea5d8df9bed6335c2191
